### PR TITLE
Add very basic tests and fix code to pass tests

### DIFF
--- a/lib/Net/Netmask.pm6
+++ b/lib/Net/Netmask.pm6
@@ -365,19 +365,17 @@ class Net::Netmask {
         self.bless(:$address :$netmask);
     }
 
+    multi method new(IPv4 $address) {
+        self.bless(:$address :netmask('255.255.255.255'));
+    }
+
     multi method new($network where *.words == 2) {
         self.new(|$network.words)
     }
 
-    multi method new(*@args) {
-        #my ($addr, $mask) = @args.flatmap( *.split(/ \s+ | '/' /) );
-        fail("Unable to parse network '{ @args }'")
-    }
-
     submethod BUILD(IPv4 :$address, IPv4 :$netmask) {
 
-        $!netmask = $netmask.split('.')[0] < 128
-          ?? $netmask.&bitflip !! $netmask;
+        $!netmask = $netmask;
 
         $!start = (
             [Z+&] ($address, $!netmask).map(*.split('.'))

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,0 +1,86 @@
+use v6.c;
+use Test;
+
+#
+# Copyright © 2018 Joelle Maslak
+# See License 
+#
+
+use Net::Netmask;
+
+my @tests = (
+    {
+        input => '0.0.0.0',
+        desc  => '0.0.0.0/32',
+        base  => '0.0.0.0',
+        mask  => '255.255.255.255',
+        bits  => 32,
+        size  => 1,
+    },
+    {
+        input => '0.0.0.0/0',
+        desc  => '0.0.0.0/0',
+        base  => '0.0.0.0',
+        mask  => '0.0.0.0',
+        bits  => 0,
+        size  => 2³²,
+    },
+    {
+        input => '192.168.75.8',
+        desc  => '192.168.75.8/32',
+        base  => '192.168.75.8',
+        mask  => '255.255.255.255',
+        bits  => 32,
+        size  => 1,
+    },
+    {
+        input => '192.168.75.8/29',
+        desc  => '192.168.75.8/29',
+        base  => '192.168.75.8',
+        mask  => '255.255.255.248',
+        bits  => 29,
+        size  => 8,
+    },
+    {
+        input => '255.255.255.255/32',
+        desc  => '255.255.255.255/32',
+        base  => '255.255.255.255',
+        mask  => '255.255.255.255',
+        bits  => 32,
+        size  => 1,
+    },
+    {
+        input => '255.255.255.255',
+        desc  => '255.255.255.255/32',
+        base  => '255.255.255.255',
+        mask  => '255.255.255.255',
+        bits  => 32,
+        size  => 1,
+    }
+);
+
+for @tests -> $test {
+    my $net = Net::Netmask.new( $test<input> );
+
+    is ~$net, $test<desc>, "Stringification (1) of $test<input>";
+    is $net.Str, $test<desc>, "Stringification (2) of $test<input>";
+    is $net.desc, $test<desc>, "desc of $test<input>";
+    
+    is $net.base, $test<base>, "base of $test<input>";
+    is $net.mask, $test<mask>, "mask of $test<input>";
+
+    is $net.bits, $test<bits>, "bits of $test<input>";
+    is $net.size, $test<size>, "size of $test<input>";
+
+    my $net2 = Net::Netmask.new( $test<base>, $test<mask> );
+    is ~$net2, ~$net, "Construction via 2 parameter new";
+
+    $net2 = Net::Netmask.new( "$test<base> $test<mask>" );
+    is ~$net2, ~$net, "Construction via 1 parameter new with netmask";
+
+    $net2 = Net::Netmask.new( :address($test<base>) :netmask($test<mask>) );
+    is ~$net2, ~$net, "Construction via 2 named parameter new";
+}
+
+done-testing;
+


### PR DESCRIPTION
Added basic construction tests.

Two bugs are fixed:

  * BUG: new('0.0.0.0/0') added a 255.255.255.255 netmask
  * BUG: new(:address(...) :netmask(...)) failed at runtime

Hi, I'm the maintainer of the Perl 5 version of Net::Netmask.  :)

I reworked the constructor somewhat - the slurpy form was erroring out on two named argument calls, and I needed to add a new constructor for bare IP construction.

I also removed the test for first octet < 128, because that can't actually happen with a valid netmask passed in.

I want to do some additional work on this module - filling out these tests and adding IPv6 are the first thoughts (I just added IPv6 support to the Perl 5 version of Net::Netmask).