### PR TITLE
Ignore .precomp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.precomp/


### PR DESCRIPTION
Add a really simple .gitignore to ignore the lib/.precomp directory that P6 creates.