### PR TITLE
Rosettacode grammer

### DIFF
--- a/lib/Net/Netmask.pm6
+++ b/lib/Net/Netmask.pm6
@@ -416,6 +416,43 @@ See LICENSE file in the repository for the full license text.
 
 class Net::Netmask {
 
+#from http://rosettacode.org/wiki/Parse_an_IP_Address#Perl_6
+#    grammar IP_Addr {
+#        token TOP { ^ [ <IPv4> | <IPv6> ] $ }
+#
+#        token IPv4 {
+#            [ <d8> +% '.' ] <?{ $<d8> == 4 }> <port>?
+#            { @*by8 = @$<d8> }
+#        }
+#
+#        token IPv6 {
+#            |     <ipv6>
+#            | '[' <ipv6> ']' <port>
+#        }
+#
+#        token ipv6 {
+#            | <h16> +% ':' <?{ $<h16> == 8 }>
+#            { @*by16 = @$<h16> }
+#
+#            | [ (<h16>) +% ':']? '::' (<h16>) +% ':' <?{ @$0 + @$1 <= 8 }>
+#            { @*by16 = @$0, '0' xx 8 - (@$0 + @$1), @$1 }
+#
+#            | '::ffff:' <IPv4>
+#            { @*by16 = '0' xx 5, 'ffff', by8to16 @*by8 }
+#        }
+#
+#        token d8  { (\d+) <?{ $0 < 256   }> }
+#        token d16 { (\d+) <?{ $0 < 65536 }> }
+#        token h16 { (<:hexdigit>+) <?{ @$0 <= 4 }> }
+#
+#        token port {
+#            ':' <d16> { $*port = +$<d16> }
+#        }
+#    }
+
+
+
+
     has Str $.address;
     has Str $.netmask;
     has Int $!start;

--- a/lib/Net/Netmask.pm6
+++ b/lib/Net/Netmask.pm6
@@ -428,7 +428,7 @@ class Net::Netmask {
         }
 
         token ipv4mask {
-            \s [ <d8> +% '.' ] <?{ $<d8> == 4 }>
+            \s [ <d8> +% '.' ] <?{ $<d8> == 4 and ((@$<d8>)».fmt("%08b").join ~~ /^1*0*$/)}>
             { make @$<d8>.join('.') }
         }
 

--- a/t/04-construction.t
+++ b/t/04-construction.t
@@ -1,4 +1,3 @@
-use v6.c;
 use Test;
 
 #
@@ -69,10 +68,8 @@ my @invalid_input_two_param  =
 for @invalid_input_two_param -> $test {
     #thows-like seems to confueses test output
     #throws-like {  my $net = Net::Netmask.new( $test<ip> ) }, Exception, message => 'failed to parse ' ~  $test<ip>, 'fail ' ~ $test<ip>  ;
-    todo 'migrate to grammer';
     dies-ok  { Net::Netmask.new( $test<address>, $test<netmask> )}, 'dies two params ' ~ $test<address> ~ ' ' ~ $test<netmask>;
     dies-ok  { Net::Netmask.new( $test<address> ~ ' ' ~ $test<netmask> )}, 'dies one param ' ~ $test<address> ~ ' ' ~ $test<netmask>;
-    todo 'migrate to grammer';
     dies-ok  { Net::Netmask.new( :address($test<address>), :netmask($test<netmask>) )}, 'dies named params ' ~ $test<address> ~ ' ' ~ $test<netmask>;
 }
 

--- a/t/04-construction.t
+++ b/t/04-construction.t
@@ -1,0 +1,22 @@
+use v6.c;
+use Test;
+
+#
+# Copyright © 2018 Lukas Valle
+# See License 
+#
+
+use Net::Netmask;
+
+my @invalid_input =
+    { :input<0.0.0.0/33> },
+    { :input<0.0.0.0 255.255.128.255> },
+    { :input<0.0.0.256'> };
+
+for @invalid_input -> $test {
+    throws-like { Net::Netmask.new( $test<input> ) },    Exception, message => 'failed to parse ' ~  $test<input> ;
+}
+
+
+done-testing;
+

--- a/t/04-construction.t
+++ b/t/04-construction.t
@@ -8,13 +8,76 @@ use Test;
 
 use Net::Netmask;
 
-my @invalid_input =
-    { :input<0.0.0.0/33> },
-    { :input<0.0.0.0 255.255.128.255> },
-    { :input<0.0.0.256'> };
+my @valid_input_ip =
+        :ip<0.0.0.0>,
+        :ip<0.0.0.255>;
 
-for @invalid_input -> $test {
-    throws-like { Net::Netmask.new( $test<input> ) },    Exception, message => 'failed to parse ' ~  $test<input> ;
+for @valid_input_ip -> $test {
+    my $net = Net::Netmask.new( $test<ip> );
+    isa-ok $net, 'Net::Netmask', 'isa Net::Netmaks ' ~ $test<ip>;
+}
+
+
+my @invalid_input_ip =
+        :ip<0.0.0.>,
+        :ip<0.0.0.256>;
+
+for @invalid_input_ip -> $test {
+    dies-ok { Net::Netmask.new( $test<ip> ) }, 'dies ' ~ $test<ip>;
+}
+
+
+my @valid_input_ip_cidr =
+        :ip<0.0.0.0/0>,
+        :ip<0.0.0.255/29>;
+
+for @valid_input_ip_cidr -> $test {
+    my $net = Net::Netmask.new( $test<ip> );
+    isa-ok $net, 'Net::Netmask', 'isa Net::Netmaks ' ~ $test<ip>;
+}
+
+
+my @invalid_input_ip_cidr =
+        :ip<0.0.0.0/33>,
+        :ip<0.0.0.256/1>;
+
+for @invalid_input_ip_cidr -> $test {
+    dies-ok { Net::Netmask.new( $test<ip> ) }, 'dies ' ~ $test<ip>;
+}
+
+
+
+my @valid_input_two_param =
+        { :address<0.0.0.0>,     :netmask<255.255.255.255> },
+        { :address<255.0.0.255>, :netmask<255.0.0.0>       };
+
+for @valid_input_two_param -> $test {
+    my $net = Net::Netmask.new( $test<address>, $test<netmask> );
+    isa-ok $net, 'Net::Netmask', 'two params ' ~ $test<address> ~ ' ' ~ $test<netmask>;
+    $net = Net::Netmask.new( $test<address> ~ ' ' ~ $test<netmask> );
+    isa-ok $net, 'Net::Netmask', 'one param ' ~ $test<address> ~ ' ' ~ $test<netmask>;
+    $net = Net::Netmask.new( $test<address> ~ ' ' ~ $test<netmask> );
+    isa-ok $net, 'Net::Netmask', 'named params ' ~ $test<address> ~ ' ' ~ $test<netmask>;
+}
+
+
+my @invalid_input_two_param  =
+        { :address<0.0.>,
+          :netmask<255.255.255.255>
+        },
+        { :address<255.0.0.255>,
+          :netmask<0.255.0.0>
+        };
+
+for @invalid_input_two_param -> $test {
+    #thows-like seems to confueses test output
+    #throws-like {  my $net = Net::Netmask.new( $test<ip> ) }, Exception, message => 'failed to parse ' ~  $test<ip>, 'fail ' ~ $test<ip>  ;
+    todo 'migrate to grammer';
+    dies-ok  { Net::Netmask.new( $test<address>, $test<netmask> )}, 'dies two params ' ~ $test<address> ~ ' ' ~ $test<netmask>;
+    todo 'grammer to check netmask';
+    dies-ok  { Net::Netmask.new( $test<address> ~ ' ' ~ $test<netmask> )}, 'dies one param ' ~ $test<address> ~ ' ' ~ $test<netmask>;
+    todo 'migrate to grammer';
+    dies-ok  { Net::Netmask.new( :address($test<address>), :netmask($test<netmask>) )}, 'dies named params ' ~ $test<address> ~ ' ' ~ $test<netmask>;
 }
 
 

--- a/t/04-construction.t
+++ b/t/04-construction.t
@@ -62,19 +62,15 @@ for @valid_input_two_param -> $test {
 
 
 my @invalid_input_two_param  =
-        { :address<0.0.>,
-          :netmask<255.255.255.255>
-        },
-        { :address<255.0.0.255>,
-          :netmask<0.255.0.0>
-        };
+        { :address<0.0.>, :netmask<255.255.255.255>   },
+        { :address<255.0.0.255>, :netmask<0.255.0.0>  },
+        { :address<255.0.0.255>, :netmask<128.255.0.0>};
 
 for @invalid_input_two_param -> $test {
     #thows-like seems to confueses test output
     #throws-like {  my $net = Net::Netmask.new( $test<ip> ) }, Exception, message => 'failed to parse ' ~  $test<ip>, 'fail ' ~ $test<ip>  ;
     todo 'migrate to grammer';
     dies-ok  { Net::Netmask.new( $test<address>, $test<netmask> )}, 'dies two params ' ~ $test<address> ~ ' ' ~ $test<netmask>;
-    todo 'grammer to check netmask';
     dies-ok  { Net::Netmask.new( $test<address> ~ ' ' ~ $test<netmask> )}, 'dies one param ' ~ $test<address> ~ ' ' ~ $test<netmask>;
     todo 'migrate to grammer';
     dies-ok  { Net::Netmask.new( :address($test<address>), :netmask($test<netmask>) )}, 'dies named params ' ~ $test<address> ~ ' ' ~ $test<netmask>;


### PR DESCRIPTION
Grammer for ip parsing base on rosettacode example: 
http://rosettacode.org/wiki/Parse_an_IP_Address#Perl_6

- more powerful parsing of IP-string
- consolidation of object construction methods
- netmask are now checked for validity
- more checks, mainly for grammer verification
- maybe useful as base for IPv6 implementation in the future

For the moment the address/netmkas values are stored as strings as before. Maybe using Arroy-of-Numbers to store the address and netmaks internally is more 'natural' than using string, as done in the rosettacode example.