### PR TITLE
SECURITY: no longer allow IPv4 octets with leading zeros

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for IP-Random
 
 {{$NEXT}}
+    - SECURITY: No longer allow IPv4 octets with leading zeros
 
 0.2.0  2019-03-30T14:13:00-06:00
     - Add IPv6 support courtesy of Lukas Vale

--- a/lib/Net/Netmask.pm6
+++ b/lib/Net/Netmask.pm6
@@ -88,7 +88,7 @@ IPv4 Addresses are validated against the following subset
 
 =begin code :lang<perl-6>
 
-token octet   { (\d+) <?{ $0 <= 255 }>  }
+token octet   { (0||<[1..9]><[0..9]>*) <?{ $0 <= 255 }>  }
 regex address { <octet> ** 4 % '.'      }
 subset IPv4 of Str where /<address>/;
 
@@ -490,7 +490,7 @@ class Net::Netmask {
             '/' <n7> { my $n = 2**128-1+<(128-$<n7>); make (0x70,0x60...0x0).map({ $n +> $_}) »%» 0x10000 }
         }
 
-        token d8  { (\d+) <?{ $0 < 256   }> }
+        token d8  { (0||<[1..9]><[0..9]>*) <?{ $0 < 256 }>  }
         token n5  { (\d+) <?{ $0 <= 32    }> }
         token n7  { (\d+) <?{ $0 <= 128   }> }
         token h16 { (<:hexdigit> ** {1..4})  }

--- a/t/99-security-leading-zero.t
+++ b/t/99-security-leading-zero.t
@@ -1,0 +1,34 @@
+use Test;
+use lib 'lib';
+
+#
+# Copyright © 2021 Joelle Maslak
+# See License 
+#
+
+use Net::Netmask;
+
+# Two security fixes were added to Perl 5's Net::Netmask:
+#
+#   1 - "Short" CIDRs (10/8, 10.0/16, etc) were no longer accepted since
+#   different software libraries interpret them differently.  One
+#   library might interpret 127.1 as 127.0.0.1 (that's the standard Unix
+#   interpretation) while others might interpret it as 127.1.0.0. Thus
+#   this can be unsafe if two libraries/utilities/etc have different
+#   interpretations.  Fortunately this was never supported by this
+#   module. This test keeps it that way.
+
+dies-ok { Net::Netmask.new("10/8"); }        # Short format should die
+
+#   2 - "Octal" CIDRs (010.0.0.0 => 8.0.0.0). When an octal octet is
+#   encountered by some Unix (and otherwise) socket libraries, it is
+#   interpreted as an OCTAL number.  This module used to interpret an
+#   octet with a leading zero as an DECIMAL number, while other tools
+#   would interpret it as an OCTAL one.  It's safer to just not accept
+#   leading zeros.
+
+dies-ok { Net::Netmask.new("10.01.2.3"); }   # Octal format not supported (rightly)
+
+done-testing;
+
+


### PR DESCRIPTION
See https://blog.urth.org/2021/03/29/security-issues-in-perl-ip-address-distros/ for a description of the problem.
